### PR TITLE
[4u7o-02] Fix rsync command for app directory sync

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Sync Files to VPS
         run: |
-          rsync -avz --exclude 'node_modules' --exclude '.git' --exclude '.github' ./app 4u7o-develop:/app
+          rsync -avz --exclude 'node_modules' --exclude '.git' --exclude '.github' ./app/ 4u7o-develop:/app
         shell: bash
 
       - name: Deploy to VPS


### PR DESCRIPTION
Ensure the rsync command includes a trailing slash for the app directory to sync files correctly.